### PR TITLE
Testidgenerator fix

### DIFF
--- a/force-app/common/classes/TestIdGenerator.cls
+++ b/force-app/common/classes/TestIdGenerator.cls
@@ -19,8 +19,7 @@ global class TestIdGenerator implements Iterator<Id> {
     }
 
     global Id next() {
-        return keyPrefix
-                + String.valueOf(count++).leftPad(4, '0')
-                + '0'.repeat(8);
+        return keyPrefix + '00'
+                + String.valueOf(count++).leftPad(10, '0');
     }
 }

--- a/force-app/common/classes/TestIdGeneratorTest.cls
+++ b/force-app/common/classes/TestIdGeneratorTest.cls
@@ -1,0 +1,26 @@
+/**
+ * @author paulk@nebulaconsulting.co.uk
+ * @date 11/03/2022
+ */
+
+@IsTest
+private class TestIdGeneratorTest {
+
+    @IsTest static void singleId() {
+
+        TestIdGenerator testIdGenerator = new TestIdGenerator(Contact.SObjectType);
+        System.assert(testIdGenerator.next() != null);
+        System.assertEquals(true, testIdGenerator.hasNext());
+
+    }
+
+    @IsTest static void largeNumberOfIds() {
+
+        TestIdGenerator testIdGenerator = new TestIdGenerator(Contact.SObjectType);
+        for (Integer i = 0; i < 10001; i++) {
+            testIdGenerator.next();
+        }
+        System.assert(testIdGenerator.next() != null);
+
+    }
+}

--- a/force-app/common/classes/TestIdGeneratorTest.cls
+++ b/force-app/common/classes/TestIdGeneratorTest.cls
@@ -9,9 +9,8 @@ private class TestIdGeneratorTest {
     @IsTest static void singleId() {
 
         TestIdGenerator testIdGenerator = new TestIdGenerator(Contact.SObjectType);
-        System.assert(testIdGenerator.next() != null);
+        System.assertEquals(Contact.SObjectType, testIdGenerator.next().getSobjectType());
         System.assertEquals(true, testIdGenerator.hasNext());
-
     }
 
     @IsTest static void largeNumberOfIds() {
@@ -20,7 +19,6 @@ private class TestIdGeneratorTest {
         for (Integer i = 0; i < 10001; i++) {
             testIdGenerator.next();
         }
-        System.assert(testIdGenerator.next() != null);
-
+        System.assertEquals(Contact.SObjectType, testIdGenerator.next().getSobjectType());
     }
 }

--- a/force-app/common/classes/TestIdGeneratorTest.cls-meta.xml
+++ b/force-app/common/classes/TestIdGeneratorTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
As per issue, TestIdGenerator fails after 100 ids.

```
nebc.TestIdGenerator t = new nebc.TestIdGenerator(Contact.SObjectType);
for (Integer i = 0; i < 10000; i++) {
    System.debug(t.next());
}
```

Proposal to change the counting to the end of the Id string, instead of where it is now.

Also added a test class, albeit very basic.