### PR TITLE
Adding header key/value to the response.

### DIFF
--- a/force-app/callouts/classes/HttpExpectation.cls
+++ b/force-app/callouts/classes/HttpExpectation.cls
@@ -32,6 +32,11 @@ global class HttpExpectation {
         return this;
     }
 
+    global HttpExpectation setResponseHeader(String key, String value) {
+        response.setHeader(key, value);
+        return this;
+    }
+
     global HttpExpectation setBodyVerification(BooleanFunction bodyVerification) {
         this.bodyVerification = bodyVerification;
         return this;

--- a/force-app/callouts/classes/HttpExpectationMockTest.cls
+++ b/force-app/callouts/classes/HttpExpectationMockTest.cls
@@ -48,4 +48,22 @@ private class HttpExpectationMockTest {
         System.assertEquals(201, response.getStatusCode());
         System.assertEquals('', response.getBody());
     }
+
+    @IsTest
+    static void getWithHeader() {
+        HttpRequest request = new HttpRequest();
+        request.setMethod(HttpMethod.HTTP_GET.name);
+        request.setEndpoint('https://foo.com/bar');
+
+        theMock.expect(new HttpExpectation('https://foo.*/bar', HttpMethod.HTTP_GET)
+            .setResponseHeader('token', '12345')
+        );
+
+        Test.startTest();
+        HttpResponse response = new Http().send(request);
+        Test.stopTest();
+
+        System.assert(theMock.isEmpty());
+        System.assertEquals('12345', response.getHeader('token'));
+    }
 }


### PR DESCRIPTION
I have an addition to the HttpExpectation class to be able to set a header key/value in the response.

There's an API that requires a login to get an authentication token, and that's returned in the header of the response. This would allow me to assert the login http request responds with a token to use on subsequent calls.