### PR TITLE
FEATURE: New convenience methods for custom / overriding standard test record generation

### DIFF
--- a/force-app/testRecordGenerator/classes/StandardTestRecordGenerators.cls
+++ b/force-app/testRecordGenerator/classes/StandardTestRecordGenerators.cls
@@ -23,6 +23,12 @@ global without sharing class StandardTestRecordGenerators {
                 Map<String, StandardTestRecordGenerator>.class);
     }
 
+    global StandardTestRecordGenerators(String testRecordGeneratorJson) {
+        allStandardGenerators = (Map<String, StandardTestRecordGenerator>)JSON.deserialize(
+                testRecordGeneratorJson,
+                Map<String, StandardTestRecordGenerator>.class);
+    }
+
     global StandardTestRecordGenerators deploy(SObjectType sObjectType) {
         return deploy(sObjectType.getDescribe().getName());
     }
@@ -35,12 +41,46 @@ global without sharing class StandardTestRecordGenerators {
         return this;
     }
 
+    global StandardTestRecordGenerators deployWithFieldOverride(String name, Map<String, String> testRecordFieldsToOverride) {
+        Metadata.Operations.enqueueDeployment(
+                getDeployContainerFor(name, testRecordFieldsToOverride),
+                new EmailResultsMetadataDeployCallback(UserInfo.getUserEmail())
+        );
+        return this;
+    }
+
     public Metadata.DeployContainer getDeployContainerFor(String name) {
         Assertion.is(
                 String.format('No standard metadata generators found for {0}. Existing definitions are: {1}',
                         new List<String>{ name, String.join(new List<String>(allStandardGenerators.keySet()), ',') }))
                 .that(allStandardGenerators.containsKey(name));
         return getDeployContainerFor(allStandardGenerators.get(name));
+    }
+
+    public Metadata.DeployContainer getDeployContainerFor(String name, Map<String, String> testRecordFieldsToOverride) {
+        Assertion.is(
+                String.format('No standard metadata generators found for {0}. Existing definitions are: {1}',
+                        new List<String>{ name, String.join(new List<String>(allStandardGenerators.keySet()), ',') }))
+                .that(allStandardGenerators.containsKey(name));
+
+        nebc.StandardTestRecordGenerators.StandardTestRecordGenerator testRecord = allStandardGenerators.get(name);
+
+        Set<String> fieldValues = new LazySObjectIterator(testRecord.fields).get(Test_Record_Generator_Field__mdt.Field__c, new Set<String>());
+
+        for (String fieldName : testRecordFieldsToOverride.keySet()) {
+            Assertion.is(
+                    String.format('No field named "{0}" found for test record object "{1}"',
+                            new List<String>{ fieldName, name }))
+                    .that(fieldValues.contains(fieldName));
+
+            for (Test_Record_Generator_Field__mdt field : testRecord.fields) {
+                if (field.Field__c == fieldName) {
+                    field.Value__c = testRecordFieldsToOverride.get(fieldName);
+                }
+            }
+        }
+
+        return getDeployContainerFor(testRecord);
     }
 
     private Metadata.DeployContainer getDeployContainerFor(StandardTestRecordGenerator standardTestRecordGenerator) {

--- a/force-app/testRecordGenerator/classes/StandardTestRecordGenerators.cls
+++ b/force-app/testRecordGenerator/classes/StandardTestRecordGenerators.cls
@@ -23,9 +23,14 @@ global without sharing class StandardTestRecordGenerators {
                 Map<String, StandardTestRecordGenerator>.class);
     }
 
-    global StandardTestRecordGenerators(String testRecordGeneratorJson) {
+    /**
+     * @description Constructor for StandardTestRecordGenerators that accepts a JSON string.
+     *              Deserializes the provided JSON into a map of standard test record generators.
+     * @param testRecordJson JSON string representing the map of standard test record generators.
+     */
+    global StandardTestRecordGenerators(String testRecordJson) {
         allStandardGenerators = (Map<String, StandardTestRecordGenerator>)JSON.deserialize(
-                testRecordGeneratorJson,
+                testRecordJson,
                 Map<String, StandardTestRecordGenerator>.class);
     }
 

--- a/force-app/testRecordGenerator/classes/StandardTestRecordGeneratorsTest.cls
+++ b/force-app/testRecordGenerator/classes/StandardTestRecordGeneratorsTest.cls
@@ -87,7 +87,7 @@ private class StandardTestRecordGeneratorsTest {
         Test.stopTest();
 
         List<Metadata.Metadata> resultMetadata = result.getMetadata();
-        System.assertEquals(13, resultMetadata.size());
+        Assert.areEqual(13, resultMetadata.size());
 
         for (Metadata.Metadata metadata : resultMetadata) {
             if (metadata.fullName == 'nebc__Test_Record_Generator_Field.User_Language_Locale_Key') {

--- a/force-app/testRecordGenerator/classes/StandardTestRecordGeneratorsTest.cls
+++ b/force-app/testRecordGenerator/classes/StandardTestRecordGeneratorsTest.cls
@@ -39,4 +39,67 @@ private class StandardTestRecordGeneratorsTest {
 
         System.assert(false, 'Should have thrown an exception');
     }
+
+    @IsTest
+    static void jsonSupplied() {
+        String testProductJson = '{\n' +
+                '    "Product2": {\n' +
+                '        "generator": {\n' +
+                '            "MasterLabel": "Product",\n' +
+                '            "DeveloperName": "Product",\n' +
+                '            "nebc__Apex_Class__c": "nebc.TestMetadataRecordGenerator",\n' +
+                '            "nebc__Priority__c": 0,\n' +
+                '            "nebc__SObject__c": "Product2"\n' +
+                '        },\n' +
+                '        "fields": [\n' +
+                '            {\n' +
+                '                "MasterLabel": "Product: Name",\n' +
+                '                "DeveloperName": "Product_Name",\n' +
+                '                "nebc__Field__c": "Name",\n' +
+                '                "nebc__Value__c": "Test Product"\n' +
+                '            },\n' +
+                '            {\n' +
+                '                "MasterLabel": "Product: IsActive",\n' +
+                '                "DeveloperName": "Product_IsActive",\n' +
+                '                "nebc__Field__c": "IsActive",\n' +
+                '                "nebc__Value__c": "false"\n' +
+                '            }\n' +
+                '        ]\n' +
+                '    }\n' +
+                '}';
+
+        Test.startTest();
+        Metadata.DeployContainer result = new StandardTestRecordGenerators(testProductJson).getDeployContainerFor('Product2');
+        Test.stopTest();
+
+        List<Metadata.Metadata> resultMetadata = result.getMetadata();
+        Assert.areEqual(3, resultMetadata.size());
+    }
+
+    @IsTest
+    static void standardTestRecordFieldOverride() {
+        Map<String, String> fieldsToOverride = new Map<String, String>{'LanguageLocaleKey' => 'en_GB'};
+
+        StandardTestRecordGenerators standardTestRecordGenerators = new StandardTestRecordGenerators();
+
+        Test.startTest();
+        Metadata.DeployContainer result = standardTestRecordGenerators.getDeployContainerFor(User.SObjectType.getDescribe().getName(), fieldsToOverride);
+        Test.stopTest();
+
+        List<Metadata.Metadata> resultMetadata = result.getMetadata();
+        System.assertEquals(13, resultMetadata.size());
+
+        for (Metadata.Metadata metadata : resultMetadata) {
+            if (metadata.fullName == 'nebc__Test_Record_Generator_Field.User_Language_Locale_Key') {
+                Metadata.CustomMetadata testRecordGeneratorMetadata = (Metadata.CustomMetadata) metadata;
+                List<Metadata.CustomMetadataValue> testRecordGeneratorMetadataValues = testRecordGeneratorMetadata.values;
+
+                for (Metadata.CustomMetadataValue metadataValue : testRecordGeneratorMetadataValues) {
+                    if (metadataValue.field == 'nebc__value__c') {
+                        Assert.areEqual(fieldsToOverride.get(fieldsToOverride.keySet().iterator().next()), metadataValue.value);
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Add ability to supply your own JSON format
- Add ability to override existing standard generator fields

This should assist with Nebula-Consulting/package-test-record-generator-ui#9